### PR TITLE
This adds support for group definition based on children

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -23,3 +23,7 @@ db-site2:
             - db4
         vars:
             - ansible_connection: winrm
+db-servers:
+        children:
+            - db-site1
+            - db-site2

--- a/inventory.py
+++ b/inventory.py
@@ -91,8 +91,8 @@ class AnsibleGitInventory(object):
             result = {}
             for group, groupdata in data.iteritems():
 		groupobj = {}
-                # Check for host definition. Could be absend due to
-                # child definition
+                # Check for host definition. Could be absent due to children
+                # definition
                 if ('hosts' in groupdata) and (groupdata['hosts'] is not None):
                     hosts = groupdata['hosts']
                     hostobj = []


### PR DESCRIPTION
The main loop which parses the yaml file, is extended to parse "children" sections. Since it's possible that such a section doesn't contain any host definitions, an explicited check has been added to only add hosts, when the 'host' key exists.